### PR TITLE
Adds a basic HTTP server with basic Auth

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -15,11 +15,9 @@ char ssid[] = SECRET_SSID;
 char server_user[] = SECRET_SERVER_USERNAME;
 char server_pass[] = SECRET_SERVER_PASSWORD;
 
-String deviceLocation = DEVICE_LOCATION;
-
 const char broker[] = MQTT_BROKER;
 const String humidityTopic  = "humidity";
-const String tempTopic  = "temp";
+const String tempTopic  = "temperature";
 int        port     = MQTT_PORT;
 
 DHT dht(DHT_PIN, DHT_TYPE);
@@ -100,7 +98,7 @@ void handleMQTTSetup() {
 }
 
 String buildTopic(String root) {
-  return root + "/" + deviceLocation;
+  return root + "/" + identifier;
 }
 
 void sendMqttMessage(String topic, String message) {
@@ -116,5 +114,5 @@ void handleMQTT() {
 
   sendMqttMessage(buildTopic(tempTopic), String(t));
   sendMqttMessage(buildTopic(humidityTopic), String(h));
-  // delay(LOOP_DELAY);
+  delay(LOOP_DELAY);
 }

--- a/main.ino
+++ b/main.ino
@@ -1,7 +1,10 @@
 #include "DHT.h"
 #include "secrets.h"
 #include "server_config.h"
+#include <ArduinoJson.h>
 #include <ArduinoMqttClient.h>
+#include <EEPROM.h>
+#include <ESP8266WebServer.h>
 #include <ESP8266WiFi.h>
 #include <string.h>
 
@@ -9,6 +12,8 @@ char mqttPass[] = SECRET_MQTT_PASS;
 char mqttUser[] = SECRET_MQTT_USER;
 char pass[] = SECRET_PASS;
 char ssid[] = SECRET_SSID;
+char server_user[] = SECRET_SERVER_USERNAME;
+char server_pass[] = SECRET_SERVER_PASSWORD;
 
 String deviceLocation = DEVICE_LOCATION;
 
@@ -18,24 +23,78 @@ const String tempTopic  = "temp";
 int        port     = MQTT_PORT;
 
 DHT dht(DHT_PIN, DHT_TYPE);
+ESP8266WebServer server(80);
 WiFiClient wifiClient;
 MqttClient mqttClient(wifiClient);
-
+String identifier = "";
 
 void setup() {
+  Serial.begin(115200);
+
+  handleWifiSetup();
+
+  // handleMQTTSetup();
+  handleServerSetup();
+
+  dht.begin();
+
+}
+
+void loop() {
+  if (WiFi.status() == WL_CONNECTED) {
+    server.handleClient();  
+    // handleMQTT();
+  }
+}
+
+// Wifi Connection Methods
+void handleWifiSetup() {
   WiFi.begin(ssid, pass);
 
   while (WiFi.status() != WL_CONNECTED) {
-    delay(WIFI_SETUP_DELAY);
+    delay(SETUP_DELAY);
   }
-  
-  dht.begin();
 
+  Serial.println("WiFi connected.");
+  Serial.print("Got IP: ");  Serial.println(WiFi.localIP());
+
+  identifier = WiFi.macAddress();
+}
+
+// HTTP Server Methods
+void handleServerSetup() {
+  server.on("/read", handleRead);
+  server.begin();
+}
+
+void handleRead()
+{
+  if (!server.authenticate(server_user, server_pass)) {
+        return server.requestAuthentication();
+  }
+  DynamicJsonDocument doc(1024);
+
+  float humidity = dht.readHumidity();
+  float temperature = dht.readTemperature();
+
+  doc["temperature"] = temperature;
+  doc["humidity"] = humidity;
+  doc["identifier"] = identifier;
+
+  String response = "";
+  serializeJson(doc, response);
+
+  server.send(200, "application/json", response);
+}
+
+// MQTT Methods
+void handleMQTTSetup() {
   if(!(mqttUser == "" || mqttPass == "")) {
     mqttClient.setUsernamePassword(mqttUser, mqttPass);
   }
 
   if (!mqttClient.connect(broker, port)) {
+    delay(SETUP_DELAY);
     while (1);
   }
 }
@@ -50,16 +109,12 @@ void sendMqttMessage(String topic, String message) {
     mqttClient.endMessage();
 }
 
-void loop() {
- 
-  if (WiFi.status() == WL_CONNECTED) {
-    mqttClient.poll();
-    float h = dht.readHumidity();
-    float t = dht.readTemperature();
+void handleMQTT() {
+  mqttClient.poll();
+  float h = dht.readHumidity();
+  float t = dht.readTemperature();
 
-    sendMqttMessage(buildTopic(tempTopic), String(t));
-    sendMqttMessage(buildTopic(humidityTopic), String(h));
-  }
-
- delay(LOOP_DELAY);
+  sendMqttMessage(buildTopic(tempTopic), String(t));
+  sendMqttMessage(buildTopic(humidityTopic), String(h));
+  // delay(LOOP_DELAY);
 }

--- a/main.ino
+++ b/main.ino
@@ -31,8 +31,9 @@ void setup() {
 
   handleWifiSetup();
 
-  // handleMQTTSetup();
+  // Uncomment either handleMQTTSetup or handleServerSetup, depending on how you want your data.
   handleServerSetup();
+  // handleMQTTSetup();
 
   dht.begin();
 
@@ -40,6 +41,7 @@ void setup() {
 
 void loop() {
   if (WiFi.status() == WL_CONNECTED) {
+    // Uncomment server.handleClient if handleServerSetup was uncommented, or handleMQTT if handleMQTTSetup was uncommented
     server.handleClient();  
     // handleMQTT();
   }

--- a/secrets.h
+++ b/secrets.h
@@ -3,3 +3,5 @@
 #define SECRET_PASS "";
 #define SECRET_MQTT_USER "";
 #define SECRET_MQTT_PASS "";
+#define SECRET_SERVER_USERNAME "";
+#define SECRET_SERVER_PASSWORD "";

--- a/server_config.h
+++ b/server_config.h
@@ -4,3 +4,4 @@
 #define MQTT_BROKER "";
 #define MQTT_PORT 1883
 #define SETUP_DELAY 500
+#define VERSION "0.0.0"

--- a/server_config.h
+++ b/server_config.h
@@ -4,4 +4,4 @@
 #define LOOP_DELAY 5000
 #define MQTT_BROKER "";
 #define MQTT_PORT 1883
-#define WIFI_SETUP_DELAY 500
+#define SETUP_DELAY 500

--- a/server_config.h
+++ b/server_config.h
@@ -1,4 +1,3 @@
-#define DEVICE_LOCATION "";
 #define DHT_PIN D5
 #define DHT_TYPE DHT11
 #define LOOP_DELAY 5000


### PR DESCRIPTION
**Issues**
Closes #1 

**Summary**
- Adds a basic HTTP server, which allows users to grab a device's unique `Identifier`, device `Version`, along with `Temperature` and `Humidity` readings from a variety of JSON endpoints, as described below

**GET** `/api/read/all/`
```
{
    "temperature": 22.5,
    "humidity": 45,
    "identifier": "##:##:##:##:##:##"
}
```
**GET** `/api/read/temperature/`
```
{
    "temperature": 22.5,
    "identifier": "##:##:##:##:##:##"
}
```
**GET** `/api/read/humidity/`
```
{
    "humidity": 45,
    "identifier": "##:##:##:##:##:##"
}
```
**GET** `/api/info/`
```
{
    "identifier": "##:##:##:##:##:##",
    "version": "#.#.#"
}
```

- Adds basic authentication, a check for a `Username` and `Password`. **WARNING** This is not a very secure method of protecting your endpoints, as the username and password are simply base64 encoded and can be read VERY easily as the server is not HTTPS encrypted. This warning will be added to the README as well. This is HOPEFULLY a temporary measure until something sturdier is put in place.