### PR TITLE
Adding function pointers for easier config

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -19,7 +19,7 @@ const char broker[] = MQTT_BROKER;
 const String humidityTopic  = "humidity";
 const String tempTopic  = "temperature";
 int        port     = MQTT_PORT;
-uint8_t config = OPTION_SERVER;
+uint8_t config = OPTION_REST;
 
 typedef struct { 
   uint8_t config;
@@ -35,12 +35,12 @@ void handleServer();
 void handleMQTT();
 
 const configDictionary setupConfig[] {
-  {OPTION_SERVER, &handleServerSetup},
+  {OPTION_REST, &handleServerSetup},
   {OPTION_MQTT, &handleMQTTSetup},
 };
 
 const configDictionary runConfig[] {
-  {OPTION_SERVER, &handleServer},
+  {OPTION_REST, &handleServer},
   {OPTION_MQTT, &handleMQTT},
 };
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -19,6 +19,30 @@ const char broker[] = MQTT_BROKER;
 const String humidityTopic  = "humidity";
 const String tempTopic  = "temperature";
 int        port     = MQTT_PORT;
+uint8_t config = OPTION_SERVER;
+
+typedef struct { 
+  uint8_t config;
+  void (*func)(void);
+} configDictionary;
+
+// Setup methods
+void handleServerSetup();
+void handleMQTTSetup();
+
+// Run methods
+void handleServer();
+void handleMQTT();
+
+const configDictionary setupConfig[] {
+  {OPTION_SERVER, &handleServerSetup},
+  {OPTION_MQTT, &handleMQTTSetup},
+};
+
+const configDictionary runConfig[] {
+  {OPTION_SERVER, &handleServer},
+  {OPTION_MQTT, &handleMQTT},
+};
 
 DHT dht(DHT_PIN, DHT_TYPE);
 ESP8266WebServer server(80);
@@ -33,9 +57,7 @@ void setup() {
 
   handleWifiSetup();
 
-  // Uncomment either handleMQTTSetup or handleServerSetup, depending on how you want your data.
-  handleServerSetup();
-  // handleMQTTSetup();
+  setupConfig[config].func();
 
   dht.begin();
 
@@ -43,9 +65,7 @@ void setup() {
 
 void loop() {
   if (WiFi.status() == WL_CONNECTED) {
-    // Uncomment server.handleClient if handleServerSetup was uncommented, or handleMQTT if handleMQTTSetup was uncommented
-    server.handleClient();  
-    // handleMQTT();
+    runConfig[config].func();
   }
 }
 
@@ -64,6 +84,10 @@ void handleWifiSetup() {
 }
 
 // HTTP Server Methods
+void handleServer() {
+  server.handleClient();  
+}
+
 void handleServerSetup() {
   server.on("/api/read/all/", handleReadAll);
   server.on("/api/read/temperature/", handleReadTemperature);

--- a/main/server_config.h
+++ b/main/server_config.h
@@ -5,5 +5,5 @@
 #define MQTT_PORT 1883
 #define SETUP_DELAY 500
 #define VERSION "0.0.0"
-#define OPTION_SERVER 0
+#define OPTION_REST 0
 #define OPTION_MQTT 1

--- a/main/server_config.h
+++ b/main/server_config.h
@@ -5,3 +5,5 @@
 #define MQTT_PORT 1883
 #define SETUP_DELAY 500
 #define VERSION "0.0.0"
+#define OPTION_SERVER 0
+#define OPTION_MQTT 1


### PR DESCRIPTION
**Issues**
- Closes #6 

**Summary**
- Refactors code to use function pointers for setup and looping. Currently, using `MQTT` or `REST` is based upon the `config` variable in `main.ino`, which can be set to either `OPTION_REST`, or `OPTION_MQTT`, as specified in `server_config.h`