### PR TITLE
Enabling configurability of MQTT Update Interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DHT sensor library Version 1.4.1
 
 AnotherTempSensor is designed to be easy to setup and use. Without any prior configuration, you should be able to flash a device and use immediately.
 
+**NOTE** By default, AnotherTempSensor does not display verbose output to the Serial Monitor for security purposes. If you wish to see verbose output of the device, you must got into `constants.h` and change `DEBUG` to `true`.
+
 Once flashed, using a computer with Postman, open up your WiFi settings and find the network `AnotherTempSensor` which you can login to using the **password** `password`.
 
 Once connected to the network `AnotherTempSensor`, in Postman, configure the below JSON body and send:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Raw JSON Body
     "pass": "", //WiFi Password for connection
     "mqttBroker": "", //The IP address or hostname for an MQTT broker
     "mqttPort": 1883, //The port number of the MQTT broker
+    "mqttUpdateInterval": 5000, //The interval in which you would like the device to publish data to the MQTT broker, in milliseconds, minimum is 500 or 0.5 seconds
     "mqttUser":"", //A username for a valid MQTT user
     "mqttPass":"", //The password for the valid MQTT user
     "restUser":"", //The username you wish to use going forward to make authenticated requests to the device
@@ -90,6 +91,7 @@ Raw JSON Body
     "pass": "",
     "mqttBroker": "",
     "mqttPort": 1883,
+    "mqttUpdateInterval": 5000,
     "mqttUser":"",
     "mqttPass":"",
     "service": 2

--- a/main/config.cpp
+++ b/main/config.cpp
@@ -38,7 +38,7 @@ bool validRESTConfig(DynamicJsonDocument doc) {
 bool validMQTTUpdateInterval(DynamicJsonDocument doc) {
     if(doc.containsKey(JSON_KEY_MQTT_UPDATE_INTERVAL)) {
         int mqttUpdateInterval = doc[JSON_KEY_MQTT_UPDATE_INTERVAL];
-        return mqttUpdateInterval >= MIN_MQTT_UPDATE_INTERVAL;
+        return mqttUpdateInterval >= MQTT_MIN_UPDATE_INTERVAL;
     }
     return false;
 }

--- a/main/config.cpp
+++ b/main/config.cpp
@@ -62,7 +62,7 @@ ICACHE_RAM_ATTR void resetConfig() {
 
     if(stored) {
         while(!WiFi.disconnect()) {
-            delay(DISCONNECT_DELAY);
+            delay(DELAY_DISCONNECT);
         }
 
         detachInterrupt(digitalPinToInterrupt(BUTTON_INPUT));
@@ -100,15 +100,15 @@ void handleConfig() {
                 String response = String("{\n\t\"success\":true,\n\t\"identifier\":\"") + WiFi.macAddress() + String("\"}");
                 configServer.send(HTTP_OK, HTTP_TYPE_JSON, response);
                 
-                delay(SEND_DELAY); //Adding slight delay in order to send the response
+                delay(DELAY_SEND); //Adding slight delay in order to send the response
                 
                 configServer.close();
                 while(!WiFi.disconnect()) {
-                    delay(DISCONNECT_DELAY);
+                    delay(DELAY_DISCONNECT);
                 }
 
                 while(!WiFi.softAPdisconnect(true)) {
-                    delay(DISCONNECT_DELAY);
+                    delay(DELAY_DISCONNECT);
                 }
 
                 detachInterrupt(digitalPinToInterrupt(BUTTON_INPUT));

--- a/main/constants.h
+++ b/main/constants.h
@@ -9,9 +9,9 @@
 #define DHT_PIN D5
 #define DHT_TYPE DHT11
 
-#define SETUP_DELAY 500
-#define SEND_DELAY 500
-#define DISCONNECT_DELAY 100
+#define DELAY_SETUP 500
+#define DELAY_SEND 500
+#define DELAY_DISCONNECT 100
 
 #define WEB_SERVER_PORT 80
 

--- a/main/constants.h
+++ b/main/constants.h
@@ -2,7 +2,7 @@
 #define CONSTANTS_H
 #include <string.h>
 
-#define DEBUG true
+#define DEBUG false
 
 #define SERIAL_FREQUENCY 115200
 

--- a/main/constants.h
+++ b/main/constants.h
@@ -2,11 +2,19 @@
 #define CONSTANTS_H
 #include <string.h>
 
+#define DEBUG true
+
+#define SERIAL_FREQUENCY 115200
+
 #define DHT_PIN D5
 #define DHT_TYPE DHT11
-#define LOOP_DELAY 5000
+
 #define SETUP_DELAY 500
 #define SEND_DELAY 500
+#define DISCONNECT_DELAY 100
+
+#define WEB_SERVER_PORT 80
+
 #define VERSION "1.0.0"
 
 #define WIFI_CHANNEL 9
@@ -14,6 +22,7 @@
 #define WIFI_MAX_CONNECTIONS 1
 #define WIFI_MAX_TRIES 20
 
+#define MIN_MQTT_UPDATE_INTERVAL 500
 #define MQTT_MAX_TRIES 20
 
 #define BUTTON_INPUT 0
@@ -37,6 +46,7 @@
 #define JSON_KEY_SERVICE_CONFIG "service"
 #define JSON_KEY_MQTT_BROKER "mqttBroker"
 #define JSON_KEY_MQTT_PORT "mqttPort"
+#define JSON_KEY_MQTT_UPDATE_INTERVAL "mqttUpdateInterval"
 #define JSON_KEY_MQTT_USER "mqttUser"
 #define JSON_KEY_MQTT_PASS "mqttPass"
 #define JSON_KEY_REST_USER "restUser"

--- a/main/constants.h
+++ b/main/constants.h
@@ -22,7 +22,7 @@
 #define WIFI_MAX_CONNECTIONS 1
 #define WIFI_MAX_TRIES 20
 
-#define MIN_MQTT_UPDATE_INTERVAL 500
+#define MQTT_MIN_UPDATE_INTERVAL 500
 #define MQTT_MAX_TRIES 20
 
 #define BUTTON_INPUT 0
@@ -76,6 +76,5 @@
 #define HTTP_BAD_MQTT_CONFIG "{\n\t\"error\":\"Invalid MQTT config, double check the config and try again.\"}"
 #define HTTP_ERROR_PARSING_BODY "{\n\t\"error\":\"Unable to parse config.\"}"
 #define HTTP_ERROR_UNABLE_TO_STORE_CONFIG "{\n\t\"error\":\"Unable to store config.\"}"
-
 
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -11,7 +11,10 @@
 int serviceConfig = OPTION_CONFIG;
 
 void setup() {
-  Serial.begin(115200);
+  if(DEBUG) {
+    Serial.begin(SERIAL_FREQUENCY);
+  }
+  
   dht.begin();
   EEPROM.begin(DOC_SIZE);
 

--- a/main/mqtt.cpp
+++ b/main/mqtt.cpp
@@ -24,7 +24,7 @@ void handleMQTTSetup() {
   int tries = 0;
 
   while (!mqttClient.connect(mqttBroker, mqttPort) && tries < MQTT_MAX_TRIES) {
-    delay(SETUP_DELAY);
+    delay(DELAY_SETUP);
     tries += 1;
   }
 

--- a/main/mqtt.cpp
+++ b/main/mqtt.cpp
@@ -45,10 +45,13 @@ void sendMqttMessage(String topic, String message) {
 
 void handleMQTT() {
   mqttClient.poll();
-  float h = dht.readHumidity();
-  float t = dht.readTemperature();
+  float humidity = dht.readHumidity();
+  float temperature = dht.readTemperature();
 
-  sendMqttMessage(buildTopic(TOPIC_TEMPERATURE), String(t));
-  sendMqttMessage(buildTopic(TOPIC_HUMIDITY), String(h));
-  delay(LOOP_DELAY);
+  sendMqttMessage(buildTopic(TOPIC_TEMPERATURE), String(temperature));
+  sendMqttMessage(buildTopic(TOPIC_HUMIDITY), String(humidity));
+  
+  DynamicJsonDocument settings = loadConfig();
+  int mqttUpdateInterval = settings[JSON_KEY_MQTT_UPDATE_INTERVAL];
+  delay(mqttUpdateInterval);
 }

--- a/main/rest.cpp
+++ b/main/rest.cpp
@@ -7,7 +7,7 @@
 #include <ESP8266WiFi.h>
 #include <string.h>
 
-ESP8266WebServer restServer(80);
+ESP8266WebServer restServer(WEB_SERVER_PORT);
 
 String version = VERSION;
 

--- a/main/utils.cpp
+++ b/main/utils.cpp
@@ -5,6 +5,18 @@
 #include <StreamUtils.h>
 #include <string.h>
 
+void printMessage(String message) {
+  if(DEBUG) {
+    Serial.print(message);
+  }
+}
+
+void printlnMessage(String message) {
+  if(DEBUG) {
+    Serial.println(message);
+  }
+}
+
 bool sameConfig(DynamicJsonDocument doc1, DynamicJsonDocument doc2) {
   bool same = true;
   String serializedDoc1;
@@ -18,7 +30,7 @@ bool sameConfig(DynamicJsonDocument doc1, DynamicJsonDocument doc2) {
 
 bool setDefaultServerConfig() {
   DynamicJsonDocument doc(DOC_SIZE);
-  char defaultConfig[] = "{\n\t\"ssid\": \"\",\n\t\"pass\": \"\",\n\t\"mqttBroker\": \"\",\n\t\"mqttPort\": 1883,\n\t\"mqttUser\":\"\",\n\t\"mqttPass\":\"\",\n\t\"restUser\":\"\",\n\t\"restPass\":\"\",\n\t\"service\": 0\n}";
+  char defaultConfig[] = "{\n\t\"ssid\": \"\",\n\t\"pass\": \"\",\n\t\"mqttBroker\": \"\",\n\t\"mqttPort\": 1883,\n\t\"mqttUser\":\"\",\n\t\"mqttPass\":\"\",\n\t\"mqttUpdateInterval\": 5000,\n\t\"restUser\":\"\",\n\t\"restPass\":\"\",\n\t\"service\": 0\n}";
   
   deserializeJson(doc, defaultConfig);
 
@@ -38,22 +50,24 @@ void printConfig(DynamicJsonDocument doc) {
   const char* pass = doc[JSON_KEY_WIFI_PASS];
   const char* mqttBroker = doc[JSON_KEY_MQTT_BROKER];
   int mqttPort = doc[JSON_KEY_MQTT_PORT];
+  int mqttUpdateInterval = doc[JSON_KEY_MQTT_UPDATE_INTERVAL];
   const char* mqttUser = doc[JSON_KEY_MQTT_USER];
   const char* mqttPass = doc[JSON_KEY_MQTT_PASS];
   const char* restUser = doc[JSON_KEY_REST_USER];
   const char* restPass = doc[JSON_KEY_REST_PASS];
 
-  Serial.println("\n===========================================");
-  Serial.print("serviceConfig: "); Serial.println(serviceConfig);
-  Serial.print("ssid: "); Serial.println(ssid);
-  Serial.print("pass: "); Serial.println(pass);
-  Serial.print("mqttBroker: "); Serial.println(mqttBroker);
-  Serial.print("mqttPort: "); Serial.println(mqttPort);
-  Serial.print("mqttUser: "); Serial.println(mqttUser);
-  Serial.print("mqttPass: "); Serial.println(mqttPass);
-  Serial.print("restUser: "); Serial.println(restUser);
-  Serial.print("restPass: "); Serial.println(restPass);
-  Serial.println("\n===========================================");
+  printlnMessage("\n===========================================");
+  printMessage("serviceConfig: "); printlnMessage(String(serviceConfig));
+  printMessage("ssid: "); printlnMessage(String(ssid));
+  printMessage("pass: "); printlnMessage(String(pass));
+  printMessage("mqttBroker: "); printlnMessage(String(mqttBroker));
+  printMessage("mqttPort: "); printlnMessage(String(mqttPort));
+  printMessage("mqttUpdateInterval: "); printlnMessage(String(mqttUpdateInterval));
+  printMessage("mqttUser: "); printlnMessage(String(mqttUser));
+  printMessage("mqttPass: "); printlnMessage(String(mqttPass));
+  printMessage("restUser: "); printlnMessage(String(restUser));
+  printMessage("restPass: "); printlnMessage(String(restPass));
+  printlnMessage("\n===========================================");
 }
 
 DynamicJsonDocument loadConfig() {
@@ -68,9 +82,9 @@ bool storeConfig(DynamicJsonDocument doc) {
   EepromStream eepromStream(ADDRESS_CONFIG, DOC_SIZE);
   serializeJson(doc, eepromStream);
   if(EEPROM.commit()) {
-    Serial.println("Wrote config to EEPROM");
+    printlnMessage("Wrote config to EEPROM");
     printConfig(loadConfig());
   } else {
-    Serial.println("Config was not written to EEPROM");
+    printlnMessage("Config was not written to EEPROM");
   }
 }

--- a/main/utils.h
+++ b/main/utils.h
@@ -3,10 +3,13 @@
 
 #include <ArduinoJson.h>
 #include <stdlib.h>
+#include <string.h>
 
+DynamicJsonDocument loadConfig();
 bool setDefaultServerConfig();
 bool storeConfig(DynamicJsonDocument doc);
-DynamicJsonDocument loadConfig();
 void printConfig(DynamicJsonDocument doc);
+void printMessage(String message);
+void printlnMessage(String message);
 
 #endif

--- a/main/wifi.cpp
+++ b/main/wifi.cpp
@@ -22,7 +22,7 @@ void handleWifiSetup() {
   const char* pass = settings[JSON_KEY_WIFI_PASS]; 
 
   while(!WiFi.disconnect()) {
-    delay(SETUP_DELAY);
+    delay(DELAY_SETUP);
   }
 
   if(ssid != "" && pass != "") {
@@ -31,7 +31,7 @@ void handleWifiSetup() {
 
     uint tries = 0;
       while (!isConnected() && tries < WIFI_MAX_TRIES) {
-        delay(SETUP_DELAY);
+        delay(DELAY_SETUP);
         tries += 1;
       }
 

--- a/main/wifi.cpp
+++ b/main/wifi.cpp
@@ -11,7 +11,7 @@ bool isConnected() {
 }
 
 void handleNoWifi() {
-  Serial.println("Unable to connect to Wifi, starting device Wifi...");
+  printlnMessage("Unable to connect to Wifi, starting device Wifi...");
   setDefaultConfig();
   WiFi.softAP(DEFAULT_DEVICE_SSID, DEFAULT_DEVICE_PASS, WIFI_CHANNEL, WIFI_VISIBLE, WIFI_MAX_CONNECTIONS);
 }
@@ -26,7 +26,7 @@ void handleWifiSetup() {
   }
 
   if(ssid != "" && pass != "") {
-    Serial.print("Connecting with ssid: \""); Serial.print(ssid); Serial.print("\" and pass: \""); Serial.print(pass); Serial.println("\"");
+    printMessage("Connecting with ssid: \""); printMessage(ssid); printMessage("\" and pass: \""); printMessage(pass); printlnMessage("\"");
     WiFi.begin(ssid, pass);
 
     uint tries = 0;
@@ -36,8 +36,8 @@ void handleWifiSetup() {
       }
 
     if(isConnected() && tries < WIFI_MAX_TRIES) {
-      Serial.println("WiFi connected.");
-      Serial.print("Got IP: ");  Serial.println(WiFi.localIP());
+      printlnMessage("WiFi connected.");
+      printMessage("Got IP: ");  printlnMessage(WiFi.localIP().toString());
       int serviceConfig = settings[JSON_KEY_SERVICE_CONFIG];
       if(serviceConfig > OPTION_MQTT || serviceConfig < OPTION_REST) {
         settings[JSON_KEY_SERVICE_CONFIG] = OPTION_CONFIG;


### PR DESCRIPTION
**Issues**
- Closes #12 

**Summary**
- Adds configurability of MQTT Update Interval, and validates that the interval must be greater than or equal to `500 milliseconds` or `0.5 seconds`
- Adds debuggable configurability, such that `DEBUG` can be set to `true` or `false` in `constants.h` and if set to `true`, output will be logged to the `Serial Monitor`, otherwise if set to `false`, it will not be logged.
- Moves several "magic numbers" to `constants.h`